### PR TITLE
Rewrites deprecated create_function file to native lambda function.

### DIFF
--- a/simple-ga-ranking.php
+++ b/simple-ga-ranking.php
@@ -272,7 +272,9 @@ class WP_Widget_Simple_GA_Ranking extends WP_Widget {
 	}
 
 }
-add_action('widgets_init', create_function('', 'return register_widget("WP_Widget_Simple_GA_Ranking");'));
+add_action('widgets_init', function() {
+	return register_widget('WP_Widget_Simple_GA_Ranking');
+});
 
 function sga_url_to_postid($url)
 {


### PR DESCRIPTION
create_function has been deprecated as of PHP 7.2. I rewrote add_action function with a native lambda function instead. This got rid of the warnings for me!